### PR TITLE
Adding rack-aware partition allocation algorithm

### DIFF
--- a/ambry-tools/src/main/java/com.github.ambry.tools/admin/PartitionManager.java
+++ b/ambry-tools/src/main/java/com.github.ambry.tools/admin/PartitionManager.java
@@ -119,7 +119,7 @@ public class PartitionManager {
         int numberOfPartitions = options.valueOf(numberOfPartitionsOpt);
         int numberOfReplicas = options.valueOf(numberOfReplicasPerDatacenterOpt);
         long replicaCapacityInBytes = options.valueOf(replicaCapacityInBytesOpt);
-        manager.allocatePartitions(numberOfPartitions, numberOfReplicas, replicaCapacityInBytes);
+        manager.allocatePartitions(numberOfPartitions, numberOfReplicas, replicaCapacityInBytes, true, false);
       } else if (operationType.compareToIgnoreCase("AddReplicas") == 0) {
         listOpt.add(partitionIdsToAddReplicasToOpt);
         listOpt.add(datacenterToAddReplicasToOpt);
@@ -135,14 +135,14 @@ public class PartitionManager {
         String datacenterToAddReplicasTo = options.valueOf(datacenterToAddReplicasToOpt);
         if (partitionIdsToAddReplicas.compareToIgnoreCase(".") == 0) {
           for (PartitionId partitionId : manager.getAllPartitions()) {
-            manager.addReplicas(partitionId, datacenterToAddReplicasTo);
+            manager.addReplicas(partitionId, datacenterToAddReplicasTo, true, false);
           }
         } else {
           String[] partitionIds = partitionIdsToAddReplicas.split(",");
           for (String partitionId : partitionIds) {
             for (PartitionId partitionInCluster : manager.getAllPartitions()) {
               if (partitionInCluster.isEqual(partitionId)) {
-                manager.addReplicas(partitionInCluster, datacenterToAddReplicasTo);
+                manager.addReplicas(partitionInCluster, datacenterToAddReplicasTo, true, false);
               }
             }
           }


### PR DESCRIPTION
- Added implementations of rack-aware partition allocation algorithms to ClusterMapManager
- Added associated test code for rack-aware allocation

This PR does not yet add CLI options to enable rack-awareness in PartitionManager.  As such, we don't have to merge this PR yet, but it would be helpful to get some code review.  For now, I have two rack-aware allocator implementations for testing/evaluation purposes.  One uses the random choice strategy described here (http://marios.io/2011/08/31/multiple_choice_paradigm/), and the other (currently unused) first shuffles the nodes and then tries the node with the most free space.

_Time to review:_ 30-40 Min.
_Primary Reviewers_: No primary reviewer for now. Just whoever wants to take a look at it.
